### PR TITLE
chore: replace set-env to ENV FILE $GITHUB_ENV

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -3,7 +3,7 @@ name: Build-Debug
 on:
   push:
     branches:
-      - "**"
+      - "master"
     tags:
       - "!*" # not a tag push
   pull_request:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           dotnet-version: 3.1.201
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
@@ -42,7 +42,7 @@ jobs:
         with:
           dotnet-version: 3.1.201
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # Create Releases
       - uses: actions/create-release@v1


### PR DESCRIPTION
* fix https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* push build on master