### PR TITLE
Drop netcoreadpp3.1 and net5.0, use net6.0 instead.

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -15,10 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
       - run: dotnet build -c Debug
       - run: dotnet test -c Debug --no-build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,11 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        with:
-          dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test -c Release --no-build -p:Version=${{ env.GIT_TAG }}

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/sandbox/ReturnMessage/ReturnMessage.csproj
+++ b/sandbox/ReturnMessage/ReturnMessage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/ProcessX.Tests/ProcessX.Tests.csproj
+++ b/tests/ProcessX.Tests/ProcessX.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## tl;dr;

.NET 3.1 and .NET 5 is EOL on 2022. Drop them on sandbox and use .NET 6 instead.