### PR TITLE
Add variant of GetDualAsyncEnumerable that returns binary

### DIFF
--- a/ProcessX.sln
+++ b/ProcessX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35913.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProcessX", "src\ProcessX\ProcessX.csproj", "{7C485BF1-5E74-4638-9179-0F535E3F4DE1}"
 EndProject
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{C4449B34-8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReturnMessage", "sandbox\ReturnMessage\ReturnMessage.csproj", "{0E468B58-A81E-450D-B4E4-32B087EBE1F7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinaryWithErrorOutput", "sandbox\BinaryWithErrorOutput\BinaryWithErrorOutput.csproj", "{7A48F390-01E7-0250-0476-A38BF76BE0F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{0E468B58-A81E-450D-B4E4-32B087EBE1F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0E468B58-A81E-450D-B4E4-32B087EBE1F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0E468B58-A81E-450D-B4E4-32B087EBE1F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A48F390-01E7-0250-0476-A38BF76BE0F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A48F390-01E7-0250-0476-A38BF76BE0F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A48F390-01E7-0250-0476-A38BF76BE0F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A48F390-01E7-0250-0476-A38BF76BE0F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +62,7 @@ Global
 		{F4E6B8E8-9F69-445C-823B-A594AB23599E} = {737CE3B1-18AD-4A89-9EA7-1EE2ACB931DD}
 		{FF47BCEA-0910-4A16-B7F7-1F92498085A8} = {E867683A-4F47-421A-B666-53178446B942}
 		{0E468B58-A81E-450D-B4E4-32B087EBE1F7} = {E867683A-4F47-421A-B666-53178446B942}
+		{7A48F390-01E7-0250-0476-A38BF76BE0F9} = {E867683A-4F47-421A-B666-53178446B942}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5585A8D-24C7-479E-8B7F-1017D80E2214}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ If stdout is binary data, you can use `StartReadBinaryAsync` to read `byte[]`.
 byte[] bin = await ProcessX.StartReadBinaryAsync($"...");
 ```
 
+For applications that send messages to Standard Error output like ffmpeg, use `StartReadBinaryWithErrOutAsync` to get both the stdout as `byte[]` and stderr as `List<string>`.
+
 Change acceptable exit codes
 ---
 In default, ExitCode is not 0 throws ProcessErrorException. You can change acceptable exit codes globally by `ProcessX.AcceptableExitCodes` property. Default is `[0]`.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ catch (ProcessErrorException ex)
 }
 ```
 
+If stdout is binary data, you can use `GetDualAsyncEnumerableBinary`.
+
+
 Read Binary Data
 ---
 If stdout is binary data, you can use `StartReadBinaryAsync` to read `byte[]`.
@@ -144,8 +147,6 @@ If stdout is binary data, you can use `StartReadBinaryAsync` to read `byte[]`.
 ```csharp
 byte[] bin = await ProcessX.StartReadBinaryAsync($"...");
 ```
-
-For applications that send messages to Standard Error output like ffmpeg, use `StartReadBinaryWithErrOutAsync` to get both the stdout as `byte[]` and stderr as `List<string>`.
 
 Change acceptable exit codes
 ---

--- a/sandbox/BinaryWithErrorOutput/BinaryWithErrorOutput.csproj
+++ b/sandbox/BinaryWithErrorOutput/BinaryWithErrorOutput.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ProcessX\ProcessX.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sandbox/BinaryWithErrorOutput/Program.cs
+++ b/sandbox/BinaryWithErrorOutput/Program.cs
@@ -1,0 +1,27 @@
+using Cysharp.Diagnostics;
+
+// messages in ffmpeg are sent to stderr
+
+var ffmpeg = @"D:\apps\ffmpeg\bin\ffmpeg.exe";
+var inputFile = @"d:\temp\Zoom.mp4";
+var command = $"{ffmpeg} -i {inputFile} -c:v libx264 -crf 60 -f mpegts -";
+
+// throws with ExitCode 0
+if (false)
+{
+    var r = await ProcessX.StartReadBinaryAsync(command);
+}
+// returns stdout (mp4) and stderr (messages)
+else if (false)
+{
+    var r = await ProcessX.StartReadBinaryWithErrOutAsync(command);
+    File.WriteAllBytes($"{inputFile}.out.mp4", r.StdOut);
+}
+// throws with ExitCode -22
+else if (true)
+{
+    var r2 = await ProcessX.StartReadBinaryWithErrOutAsync(command.Replace("mpegts", "mp4", StringComparison.InvariantCulture));
+    File.WriteAllBytes($"{inputFile}.out.mp4", r2.StdOut);
+}
+
+Console.ReadLine();


### PR DESCRIPTION
- This PR introduces a new method ~~`StartReadBinaryWithErrOutAsync`~~ that addresses a limitation in the current implementation.

- When executing apps that write diagnostic messages to **stderr** while also producing binary output on stdout (e.g. ffmpeg), the current implementation fails to capture the binary output correctly. Even when the process exits with a successful code (0), the binary output is lost.

- The implementation has been tested with the example in `sandbox/BinaryWithErrorOutput` which demonstrates the functionality with a real-world scenario.