### PR TITLE
ci: use OIDC for NuGet package push authentication

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -16,6 +16,7 @@ jobs:
   build-dotnet:
     permissions:
       contents: read
+      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -41,6 +41,10 @@ jobs:
         if: ${{ !inputs.dry-run }}
         env:
           NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   # release
   create-release:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -25,7 +25,7 @@ jobs:
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build -p:Version=${{ inputs.tag }}
-      - run: dotnet pack  -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
+      - run: dotnet pack  -c Release --no-build -p:Version=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:
           name: nuget

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -30,6 +30,16 @@ jobs:
           name: nuget
           path: ./publish
           retention-days: 1
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   # release
   create-release:
@@ -42,5 +52,5 @@ jobs:
       commit-id: ""
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
-      nuget-push: true
+      nuget-push: false
     secrets: inherit


### PR DESCRIPTION
This updates the build-release workflow to leverage OpenID Connect (OIDC) for authenticating with NuGet.org. The package push operation is now performed directly within the build job, replacing static API key usage with ephemeral credentials for enhanced security.
